### PR TITLE
style: improve readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.vscode
+.idea
+
 .DS_Store

--- a/mkv_to_mp4.sh
+++ b/mkv_to_mp4.sh
@@ -1,6 +1,5 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
-#
 # - Summary
 #
 #   Convert anime BDrip (with mkv format, track 0 HEVC, track 1 FLAC)
@@ -23,30 +22,29 @@
 #
 #   Yang-Xijie
 #   https://github.com/Yang-Xijie
-#
 
-turn=1 # counter, make name of intermediate files short.
+i=1 # counter, make name of intermediate files short.
 
-for anime in **/*.mkv; do
-    echo "=====" "[""$turn""]""START" "$anime" "====="
+for anime in **/*.mkv {
+    echo "===== [$i] START $anime ====="
 
     # Firstly, extract tracks from mkv file.
     # Here, 0 and 1 refer to tracks of the mkv file.
-    mkvextract tracks "$anime" 0:"$turn"".h265" 1:"$turn"".flac"
+    mkvextract tracks "$anime" "0:$i.h265" "1:$i.flac"
 
     # Secondly, for the audio, change FLAC (Free Lossless Audio Codec) to ALAC (Apple Lossless Audio Codec).
     # (FLAC is not that compatible with FCP)
-    ffmpeg -i "$turn"".flac" -vcodec copy -acodec alac "$turn"".m4a"
+    ffmpeg -i "$i.flac" -vcodec copy -acodec alac "$i.m4a"
 
     # Then use `mp4box` to put hevc and alac together in an mp4 package.
-    mp4box -add "$turn"".h265" -add "$turn"".m4a" "${anime%.*}"".mp4"
+    mp4box -add "$i.h265" -add "$i.m4a" "${anime%.*}.mp4"
 
-    # Finally, don't forget to delete intermidiate files.
+    # Finally, don't forget to delete intermediate files.
     # If you want to move files to trash, use `brew install trash` and then change `rm` to `trash`.
-    rm "$turn"".h265" "$turn"".flac" "$turn"".m4a"
+    rm "$i.h265" "$i.flac" "$i.m4a"
 
-    echo "=====" "[""$turn""]""DONE!" "=====\n\n"
-    let turn=$turn+1
-done
+    echo "===== [$i] DONE! =====\n\n"
+    let i=$i+1
+}
 
 echo "ALL DONE!\n"

--- a/other_scripts/flac_to_alac.sh
+++ b/other_scripts/flac_to_alac.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # - Summary
 #   Convert FLAC(.flac) to ALAC(.m4a)
@@ -9,15 +9,15 @@
 #   Yang-Xijie
 #   https://github.com/Yang-Xijie
 
-turn=1 # counter
+i=1 # counter
 
-for song in **/*.flac; do
-  echo "=====" "[""$turn""]""START" "$song" "====="
+for song in **/*.flac {
+  echo "===== [$i] START $song ====="
 
   ffmpeg -i "$song" -vcodec copy -acodec alac "${song%.*}.m4a"
 
-  echo "=====" "[""$turn""]""DONE!" "$song" "=====\n\n"
-  let turn=$turn+1
-done
+  echo "===== [$i] DONE! $song =====\n\n"
+  let i=$i+1
+}
 
 echo "ALL DONE!\n"

--- a/other_scripts/m2ts_to_mov.sh
+++ b/other_scripts/m2ts_to_mov.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # - Summary
 #   Convert BDMV anime (with m2ts format, track 0 H264/AVC, track 1 PCM)
@@ -13,16 +13,16 @@
 #   Yang-Xijie
 #   https://github.com/Yang-Xijie
 
-turn=1 # counter
+i=1 # counter
 
-for anime in **/*.m2ts; do
-  echo "=====" "[""$turn""]""START" "$anime" "====="
+for anime in **/*.m2ts {
+  echo "===== [$i] START $anime ====="
 
-  ffmpeg -i "$anime" -map 0:0 -map 0:1 -vcodec copy -acodec alac "${anime%.*}"".mov"
+  ffmpeg -i "$anime" -map 0:0 -map 0:1 -vcodec copy -acodec alac "${anime%.*}.mov"
   # `-map 0:0` refers to the video track while `-map 0:1` refers to the audio track
 
-  echo "=====" "[""$turn""]""DONE!" "=====\n\n"
-  let turn=$turn+1
-done
+  echo "===== [$i] DONE! =====\n\n"
+  let i=$i+1
+}
 
 echo "ALL DONE!\n"


### PR DESCRIPTION
- For best compatibility, use `#!/usr/bin/env zsh`
  instead of hardcoded `#!/bin/zsh`
- No blank comment lines at head or end
- Remove unnecessary quotes
- Rename `turn` to `i`
- Empty line at EOF
- bracket style